### PR TITLE
Version 1.0.9

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,9 +2,21 @@
 Theme: Baton Pro
 Author: Slocum Themes/Slocum Design Studio
 Author URI: https://slocumthemes.com/
-Current Version: 1.0.8
+Current Version: 1.0.9
 ==========================================
 
+
+1.0.9 // February 08 2016
+-------------------------
+- Fixed possible PHP fatal error in the Customizer due to Customizer changesets; Thanks Andrew Nyquist
+- Fixed issue where footer widget display did not update in the Customizer Previewer due to the
+  global $sidebars_widgets data not being updated
+- Fixed a display issue where Conductor Widget display was not correct in some cases due to
+  CSS pseudo-elements
+- Adjusted CSS for Conductor Slider add-on displays
+- Removed extra Gravity Forms CSS from green color scheme stylesheet
+- Added missing Customizer controls for background image properties (preset, position, and size)
+- Added missing text domain to translation function
 
 1.0.8 // December 30 2016
 -------------------------

--- a/css/green.css
+++ b/css/green.css
@@ -355,14 +355,6 @@ nav .primary-nav .children .children:after{
 	color: #abb3ad;
 }
 
-/* Front Page Gravity Forms */
-body .mc-gravity, body .mc_gravity,
-body .mc-newsletter, body .mc_newsletter,
-body .mc-gravity_wrapper, body .mc_gravity_wrapper,
-body .mc-newsletter_wrapper, body .mc_newsletter_wrapper {
-	background: #fff;
-}
-
 /* Comments */
 .article-post-navigation a, .comments-navigation a {
 	color: #323b48;

--- a/footer.php
+++ b/footer.php
@@ -1,5 +1,8 @@
 <?php
-	global $sidebars_widgets, $sds_theme_options;
+	global $sds_theme_options;
+
+	// Grab the sidebars widgets
+	$sidebars_widgets = wp_get_sidebars_widgets();
 
 	// Bail if accessed directly
 	if ( ! defined( 'ABSPATH' ) )

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@
  * Text Domain: baton
  * Author: Slocum Studio
  * Author URI: https://slocumthemes.com/
- * Version: 1.0.8
+ * Version: 1.0.9
  * License: GPL2+
  * License URI: http://www.gnu.org/licenses/gpl.html
  * Tags: blue, green, orange, pink, purple, red, white, light, two-columns, left-sidebar, fluid-layout, custom-colors, custom-menu, editor-style, featured-images, full-width-template, sticky-post, theme-options, threaded-comments
@@ -786,12 +786,16 @@ a img.aligncenter {
 .baton-note-sidebar .conductor-widget,
 .baton-note-sidebar .widget.conductor-widget,
 .baton-note-sidebar .conductor-widget .baton-note-sidebar-widget-in,
-.baton-note-sidebar .widget.conductor-widget .baton-note-sidebar-widget-in {
+.baton-note-sidebar .widget.conductor-widget .baton-note-sidebar-widget-in,
+.baton-note-sidebar .conductor-row.conductor-widget-single-flexbox-wrap {
+	width: 100%;
+	margin: auto;
 	max-width: 1272px;
 }
 
 .baton-note-sidebar .conductor-widget.conductor-flex,
-.baton-note-sidebar .widget.conductor-widget.conductor-flex {
+.baton-note-sidebar .widget.conductor-widget.conductor-flex,
+.baton-note-sidebar .conductor-row.conductor-widget-single-flexbox-wrap {
 	padding: 2em 1rem;
 	margin-bottom: 0;
 }
@@ -1199,6 +1203,10 @@ a img.aligncenter {
 /**
  * Conductor
  */
+.conductor-widget.cf:before, .conductor-widget.cf:after {
+	display: none;
+}
+
 .conductor-content, .conductor-primary-sidebar, .conductor-secondary-sidebar,
 .conductor-cols-2-r .conductor-content,
 .conductor-cols-2-r .conductor-primary-sidebar,
@@ -1273,7 +1281,8 @@ a img.aligncenter {
 }
 
 .front-page-widgets .conductor-widget.conductor-flex,
-.front-page-widgets .widget.conductor-widget.conductor-flex {
+.front-page-widgets .widget.conductor-widget.conductor-flex,
+.front-page-widgets .widget.conductor-qb-widget.conductor-flex {
 	padding: 2em 1rem;
 	margin-bottom: 0;
 }
@@ -1999,7 +2008,8 @@ a img.aligncenter {
 	display: block;
 }
 
-.front-page-widgets .conductor-widget.conductor-slider-testimonials-wrap .widget.conductor-widget.conductor-flex {
+.front-page-widgets .conductor-widget.conductor-slider-testimonials-wrap .widget.conductor-widget.conductor-flex,
+.front-page-widgets .conductor-widget.conductor-slider-testimonials-wrap .widget.conductor-qb-widget.conductor-flex {
 	padding-left: 2.2222222rem;
 	padding-right: 2.2222222rem;
 }
@@ -2044,7 +2054,8 @@ a img.aligncenter {
 	margin-right: auto;
 }
 
-.front-page-widgets .conductor-slider-hero-slider .in.conductor-row {
+.front-page-widgets .conductor-slider-hero-slider .in.conductor-row,
+.front-page-widgets .conductor-widget.conductor-slider-hero-widget-wrap .conductor-slider .conductor-slider-hero-wrap {
 	padding: 0;
 }
 
@@ -2071,7 +2082,9 @@ a img.aligncenter {
 }
 
 .front-page-widgets .conductor-slider-news-wrap .conductor-widget.conductor-flex,
-.front-page-widgets .conductor-slider-news-wrap .widget.conductor-widget.conductor-flex {
+.front-page-widgets .conductor-slider-news-wrap .widget.conductor-widget.conductor-flex,
+.front-page-widgets .conductor-slider-news-wrap .conductor-qb-widget.conductor-flex,
+.front-page-widgets .conductor-slider-news-wrap .widget.conductor-qb-widget.conductor-flex {
 	padding-top: 0;
 	padding-bottom: 0;
 }
@@ -3433,6 +3446,7 @@ body .mc-gravity_wrapper .gform_fields input, body .mc_gravity_wrapper .gform_fi
 body .mc-newsletter_wrapper .gform_fields input, body .mc_newsletter_wrapper .gform_fields input {
 	width: 100% !important;
 	padding: 0.6em !important;
+	line-height: 1.5em !important;
 }
 
 body .gform_wrapper.mc-gravity_wrapper .gform_fields .gfield_error input,
@@ -3498,6 +3512,7 @@ body .mc-newsletter_wrapper .gform_footer .button, body .mc_newsletter_wrapper .
 	width: 100% !important;
 	margin: 0 !important;
 	padding: 0.6em 1% !important; /* !important for IE */
+	line-height: 1.5em !important;
 	white-space: pre-wrap;
 }
 
@@ -3931,7 +3946,8 @@ body .mc_newsletter_wrapper .gform_fields .gfield {
 		padding-right: 3.3333333rem;
 	}
 
-	.front-page-widgets .conductor-widget.conductor-slider-testimonials-wrap .widget.conductor-widget.conductor-flex {
+	.front-page-widgets .conductor-widget.conductor-slider-testimonials-wrap .widget.conductor-widget.conductor-flex,
+	.front-page-widgets .conductor-widget.conductor-slider-testimonials-wrap .widget.conductor-qb-widget.conductor-flex{
 		max-width: none;
 		padding-left: 0;
 		padding-right: 0;
@@ -4378,7 +4394,7 @@ body .mc_newsletter_wrapper .gform_fields .gfield {
 	body .mc-newsletter .gform_footer, body .mc_newsletter .gform_footer,
 	body .mc-gravity_wrapper .gform_footer, body .mc_gravity_wrapper .gform_footer,
 	body .mc-newsletter_wrapper .gform_footer, body .mc_newsletter_wrapper .gform_footer {
-		width: 100%;
+		width: 100% !important;
 		margin: 0 10%;
 		text-align: center;
 	}

--- a/theme/class-baton-customizer.php
+++ b/theme/class-baton-customizer.php
@@ -557,6 +557,7 @@ if ( ! class_exists( 'Baton_Customizer' ) ) {
 				$background_color_control->section = 'baton_background_body'; // Adjust Section
 				$background_color_control->priority = 10; // Adjust Priority
 			}
+
 			if ( $background_color_setting = $wp_customize->get_setting( 'background_color' ) ) // Get Setting
 				$background_color_setting->transport = 'refresh'; // Adjust Transport
 
@@ -573,19 +574,35 @@ if ( ! class_exists( 'Baton_Customizer' ) ) {
 			}
 
 			/**
+			 * Background Preset
+			 */
+			if ( $background_preset_control = $wp_customize->get_control( 'background_preset' ) ) { // Get Control
+				$background_preset_control->section = 'baton_background_body'; // Adjust Section
+				$background_preset_control->priority = 30; // Adjust Priority
+			}
+
+			/**
+			 * Background Position
+			 */
+			if ( $background_position_control = $wp_customize->get_control( 'background_position' ) ) { // Get Control
+				$background_position_control->section = 'baton_background_body'; // Adjust Section
+				$background_position_control->priority = 40; // Adjust Priority
+			}
+
+			/**
+			 * Background Size
+			 */
+			if ( $background_size_control = $wp_customize->get_control( 'background_size' ) ) { // Get Control
+				$background_size_control->section = 'baton_background_body'; // Adjust Section
+				$background_size_control->priority = 50; // Adjust Priority
+			}
+
+			/**
 			 * Background Repeat
 			 */
 			if ( $background_repeat_control = $wp_customize->get_control( 'background_repeat' ) ) { // Get Control
 				$background_repeat_control->section = 'baton_background_body'; // Adjust Section
-				$background_repeat_control->priority = 30; // Adjust Priority
-			}
-
-			/**
-			 * Background Position X
-			 */
-			if ( $background_position_x_control = $wp_customize->get_control( 'background_position_x' ) ) { // Get Control
-				$background_position_x_control->section = 'baton_background_body'; // Adjust Section
-				$background_position_x_control->priority = 40; // Adjust Priority
+				$background_repeat_control->priority = 60; // Adjust Priority
 			}
 
 			/**
@@ -593,7 +610,7 @@ if ( ! class_exists( 'Baton_Customizer' ) ) {
 			 */
 			if ( $background_attachment_control = $wp_customize->get_control( 'background_attachment' ) ) { // Get Control
 				$background_attachment_control->section = 'baton_background_body'; // Adjust Section
-				$background_attachment_control->priority = 50; // Adjust Priority
+				$background_attachment_control->priority = 70; // Adjust Priority
 			}
 
 
@@ -2911,7 +2928,8 @@ if ( ! class_exists( 'Baton_Customizer' ) ) {
 					$r .= '.baton-note-sidebar .conductor-widget,' . "\n";
 					$r .= '.baton-note-sidebar .widget.conductor-widget,' . "\n";
 					$r .= '.baton-note-sidebar .conductor-widget .baton-note-sidebar-widget-in,' . "\n";
-					$r .= '.baton-note-sidebar .widget.conductor-widget .baton-note-sidebar-widget-in {' . "\n";
+					$r .= '.baton-note-sidebar .widget.conductor-widget .baton-note-sidebar-widget-in,' . "\n";
+					$r .= '.baton-note-sidebar .conductor-row.conductor-widget-single-flexbox-wrap {' . "\n";
 						$r .= 'max-width: ' . $theme_mod_baton_max_width . 'px;' . "\n";
 					$r .= '}' . "\n\n";
 				}

--- a/theme/class-baton.php
+++ b/theme/class-baton.php
@@ -4,7 +4,7 @@
  *
  * @class Baton
  * @author Slocum Studio
- * @version 1.0.8
+ * @version 1.0.9
  * @since 1.0.0
  */
 
@@ -17,7 +17,7 @@ if ( ! class_exists( 'Baton' ) ) {
 		/**
 		 * @var string, Current version number
 		 */
-		public $version = '1.0.8';
+		public $version = '1.0.9';
 
 		/**
 		 * @var string, Slug for Slocum Theme support
@@ -1294,9 +1294,6 @@ if ( ! class_exists( 'Baton' ) ) {
 			// Grab the Baton Theme Helper instance
 			$baton_theme_helper = Baton_Theme_Helper();
 
-			// Grab the Baton Customizer Fonts instance
-			$baton_customizer_fonts = Baton_Customizer_Fonts();
-
 			// Core editor styles
 			add_editor_style( 'css/editor-style.css' );
 
@@ -1309,9 +1306,15 @@ if ( ! class_exists( 'Baton' ) ) {
 				// Lato and Martel Sans
 				$google_web_fonts = 'Lato:400,700,900|Martel+Sans:400,600';
 
-				// If we have Google Web Font support and have Google Web Fonts selected
-				if ( $baton_theme_helper->has_google_web_font_support() && ! $baton_customizer_fonts->has_default_font_families( true ) )
-					$google_web_fonts .= '|' . $baton_customizer_fonts->get_google_web_font_stylesheet_families();
+				// If the Baton_Customizer_Fonts() function exists
+				if ( function_exists( 'Baton_Customizer_Fonts' ) ) {
+					// Grab the Baton Customizer Fonts instance
+					$baton_customizer_fonts = Baton_Customizer_Fonts();
+
+					// If we have Google Web Font support and have Google Web Fonts selected
+					if ( $baton_theme_helper->has_google_web_font_support() && ! $baton_customizer_fonts->has_default_font_families( true ) )
+						$google_web_fonts .= '|' . $baton_customizer_fonts->get_google_web_font_stylesheet_families();
+				}
 
 				add_editor_style( str_replace( ',', '%2C', $protocol . '://fonts.googleapis.com/css?family=' . $google_web_fonts ) ); // Google Web Fonts
 			}
@@ -1938,7 +1941,7 @@ if ( ! class_exists( 'Baton' ) ) {
 			if ( ! isset( $templates['baton-hero-3'] ) )
 				$templates['baton-hero-3'] = array(
 					// Label
-					'label' => __( 'Baton Hero 3 (Content Left)' ),
+					'label' => __( 'Baton Hero 3 (Content Left)', 'baton' ),
 					// Placeholder Content
 					'placeholder' => sprintf( '<h3>%1$s</h3>
 								<p>%2$s</p>',


### PR DESCRIPTION
- Fixed possible PHP fatal error in the Customizer due to Customizer changesets; Thanks Andrew Nyquist
- Fixed issue where footer widget display did not update in the Customizer Previewer due to the global $sidebars_widgets data not being updated
- Fixed a display issue where Conductor Widget display was not correct in some cases due to CSS pseudo-elements
- Adjusted CSS for Conductor Slider add-on displays
- Removed extra Gravity Forms CSS from green color scheme stylesheet
- Added missing Customizer controls for background image properties (preset, position, and size)
- Added missing text domain to translation function