### PR TITLE
Version 1.1.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,9 +2,15 @@
 Theme: Baton Pro
 Author: Slocum Themes/Slocum Design Studio
 Author URI: https://slocumthemes.com/
-Current Version: 1.1.0
+Current Version: 1.1.1
 ==========================================
 
+
+1.1.1 // March 10 2017
+----------------------
+- Adjusted CSS for Conductor Widgets in various configurations/areas
+- Fixed a display bug where WooCommerce up-sells on single products were too small
+- Fixed a display bug where mc-gravity confirmation had a white background
 
 1.1.0 // March 01 2017
 ----------------------

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@
  * Text Domain: baton-pro
  * Author: Slocum Studio
  * Author URI: https://slocumthemes.com/
- * Version: 1.1.0
+ * Version: 1.1.1
  * License: GPL2+
  * License URI: http://www.gnu.org/licenses/gpl.html
  * Tags: one-column, two-columns, left-sidebar, right-sidebar, grid-layout, custom-background, custom-colors, custom-menu, editor-style, featured-images, footer-widgets, full-width-template, sticky-post, theme-options, threaded-comments, translation-ready, blog, e-commerce, education, entertainment, food-and-drink, news, photography, portfolio
@@ -1370,7 +1370,8 @@ a img.aligncenter {
 	padding-right: 0;
 }
 
-.sidebar .conductor-widget .content .article-post-meta {
+.sidebar .conductor-widget .content .article-post-meta,
+.sidebar .conductor-widget .content .article-post-meta.has-meta {
 	padding-left: 1rem;
 	padding-right: 1rem;
 }
@@ -1669,6 +1670,7 @@ a img.aligncenter {
 	color: #363a42;
 }
 
+/* TODO: This might break normal Conductor displays in content (QB shortcode) */
 .conductor-widget .post-content .article-content-more-link p {
 	margin-top: 0 !important; /* !important due to Conductor CSS */
 	margin-bottom: 0 !important; /* !important due to Conductor CSS */
@@ -1690,9 +1692,14 @@ a img.aligncenter {
 .conductor-widget-wrap .conductor-widget .content .article-title-wrap,
 .conductor-widget-wrap .conductor-widget .content .article-content,
 .conductor-widget-wrap .conductor-widget .article-post-meta,
+.conductor-widget-wrap .conductor-widget .article-post-meta.has-meta,
 .conductor-widget-wrap .conductor-widget .custom-field {
 	margin-top: 1.5rem;
 	margin-bottom: 1.5rem;
+}
+
+.conductor-widget-wrap .conductor-widget .post-content .custom-field p {
+	margin: 0 !important;
 }
 
 .conductor-widget-wrap .conductor-widget .post-content .article-content p:first-child {
@@ -1769,14 +1776,19 @@ a img.aligncenter {
 }
 
 .conductor-widget-2-columns .article-post-meta,
-.conductor-widget-3-columns .article-post-meta {
+.conductor-widget-2-columns .article-post-meta.has-meta,
+.conductor-widget-3-columns .article-post-meta,
+.conductor-widget-3-columns .article-post-meta.has-meta {
 	padding-top: 1rem;
 	padding-bottom: 1rem;
 }
 
 .conductor-widget-4-columns .article-post-meta,
+.conductor-widget-4-columns .article-post-meta.has-meta,
 .conductor-widget-5-columns .article-post-meta,
-.conductor-widget-6-columns .article-post-meta {
+.conductor-widget-5-columns .article-post-meta.has-meta,
+.conductor-widget-6-columns .article-post-meta,
+.conductor-widget-6-columns .article-post-meta.has-meta {
 	padding-top: 0.5rem;
 	padding-bottom: 0.5rem;
 }
@@ -1784,6 +1796,8 @@ a img.aligncenter {
 .conductor-widget-2-columns .content .article-title-wrap,
 .conductor-widget-2-columns .content .article-content,
 .conductor-widget-2-columns .article-post-meta,
+.conductor-widget-2-columns .article-post-meta.has-meta,
+.conductor-widget-2-columns.conductor-flex .custom-field,
 .conductor-flex .conductor-widget-2-columns .custom-field,
 .conductor.conductor-baton-landing-page-active .conductor-flex .conductor-widget-2-columns .custom-field,
 .baton-note-sidebar .conductor-flex .conductor-widget-2-columns .custom-field {
@@ -1794,6 +1808,7 @@ a img.aligncenter {
 .conductor-widget-3-columns .content .article-title-wrap,
 .conductor-widget-3-columns .content .article-content,
 .conductor-widget-3-columns .article-post-meta,
+.conductor-widget-3-columns .article-post-meta.has-meta,
 .conductor-widget-3-columns.conductor-flex .custom-field,
 .conductor.conductor-baton-landing-page-active .conductor-flex .conductor-widget-3-columns .custom-field,
 .baton-note-sidebar .conductor-flex .conductor-widget-3-columns .custom-field {
@@ -1804,6 +1819,7 @@ a img.aligncenter {
 .conductor-widget-4-columns .content .article-title-wrap,
 .conductor-widget-4-columns .content .article-content,
 .conductor-widget-4-columns .article-post-meta,
+.conductor-widget-4-columns .article-post-meta.has-meta,
 .conductor-widget-4-columns.conductor-flex .custom-field,
 .conductor.conductor-baton-landing-page-active .conductor-flex .conductor-widget-4-columns .custom-field,
 .baton-note-sidebar .conductor-flex .conductor-widget-4-columns .custom-field {
@@ -1814,12 +1830,14 @@ a img.aligncenter {
 .conductor-widget-5-columns .content .article-title-wrap,
 .conductor-widget-5-columns .content .article-content,
 .conductor-widget-5-columns .article-post-meta,
+.conductor-widget-5-columns .article-post-meta.has-meta,
 .conductor-widget-5-columns.conductor-flex .custom-field,
 .conductor.conductor-baton-landing-page-active .conductor-flex .conductor-widget-5-columns .custom-field,
 .baton-note-sidebar .conductor-flex .conductor-widget-5-columns .custom-field,
 .conductor-widget-6-columns .content .article-title-wrap,
 .conductor-widget-6-columns .content .article-content,
 .conductor-widget-6-columns .article-post-meta,
+.conductor-widget-6-columns .article-post-meta.has-meta,
 .conductor-widget-6-columns.conductor-flex .custom-field,
 .conductor.conductor-baton-landing-page-active .conductor-flex .conductor-widget-6-columns .custom-field,
 .baton-note-sidebar .conductor-flex .conductor-widget-3-columns .custom-field {
@@ -1922,7 +1940,9 @@ a img.aligncenter {
 }
 
 .conductor-widget.conductor-list-item .article-post-meta,
-.conductor-table .article-post-meta {
+.conductor-widget.conductor-list-item .article-post-meta.has-meta,
+.conductor-table .article-post-meta,
+.conductor-table .article-post-meta.has-meta {
 	width: auto;
 	padding: 0 1em;
 }
@@ -1940,7 +1960,8 @@ a img.aligncenter {
 	padding: 0 1rem;
 }
 
-.conductor-widget-grid .article-post-meta {
+.conductor-widget-grid .article-post-meta,
+.conductor-widget-grid .article-post-meta.has-meta {
 	padding: 1rem;
 }
 
@@ -3537,6 +3558,7 @@ body .mc-gravity-confirmation, body .mc_gravity-confirmation, body .mc-newslette
 body .mc-gravity-confirmation .gform_confirmation_wrapper, body .mc_gravity-confirmation .gform_confirmation_wrapper,
 body .mc-newsletter-confirmation .gform_confirmation_wrapper, body .mc_newsletter-confirmation .gform_confirmation_wrapper {
 	padding: 0;
+	background: transparent;
 	border: none;
 }
 
@@ -3753,7 +3775,7 @@ body .mc_newsletter_wrapper .gform_fields .gfield {
 
 .woocommerce ul.products li.product,
 .woocommerce-page ul.products li.product {
-	width: calc(33.333% - 2rem );
+	width: calc(33.333% - 2rem);
 	margin: 1rem;
 	padding: 0 0 1.5rem;
 	float: none;
@@ -3915,6 +3937,11 @@ body .mc_newsletter_wrapper .gform_fields .gfield {
 	width: 100%;
 	margin: 0;
 	padding: 0 0 2rem;
+}
+
+.woocommerce div.product .up-sells,
+.woocommerce-page div.product .up-sells {
+	width: 100%;
 }
 
 
@@ -4090,18 +4117,21 @@ body .mc_newsletter_wrapper .gform_fields .gfield {
 	.conductor-widget-2-columns .content .article-title-wrap,
 	.conductor-widget-2-columns .content .article-content,
 	.conductor-widget-2-columns .article-post-meta,
+	.conductor-widget-2-columns .article-post-meta.has-meta,
 	.conductor-widget-2-columns.conductor-flex .custom-field,
 	.conductor.conductor-baton-landing-page-active .conductor-flex .conductor-widget-2-columns .custom-field,
 	.baton-note-sidebar .conductor-flex .conductor-widget-2-columns .custom-field,
 	.conductor-widget-5-columns .content .article-title-wrap,
 	.conductor-widget-5-columns .content .article-content,
 	.conductor-widget-5-columns .article-post-meta,
+	.conductor-widget-5-columns .article-post-meta.has-meta,
 	.conductor-widget-5-columns.conductor-flex .custom-field,
 	.conductor.conductor-baton-landing-page-active .conductor-flex .conductor-widget-5-columns .custom-field,
 	.baton-note-sidebar .conductor-flex .conductor-widget-5-columns .custom-field,
 	.conductor-widget-6-columns .content .article-title-wrap,
 	.conductor-widget-6-columns .content .article-content,
 	.conductor-widget-6-columns .article-post-meta,
+	.conductor-widget-6-columns .article-post-meta.has-meta,
 	.conductor-widget-6-columns.conductor-flex .custom-field,
 	.conductor.conductor-baton-landing-page-active .conductor-flex .conductor-widget-6-columns .custom-field,
 	.baton-note-sidebar .conductor-flex .conductor-widget-6-columns .custom-field {
@@ -4695,18 +4725,21 @@ body .mc_newsletter_wrapper .gform_fields .gfield {
 	.conductor-widget-2-columns .content .article-title-wrap,
 	.conductor-widget-2-columns .content .article-content,
 	.conductor-widget-2-columns .article-post-meta,
+	.conductor-widget-2-columns .article-post-meta.has-meta,
 	.conductor-widget-2-columns.conductor-flex .custom-field,
 	.conductor.conductor-baton-landing-page-active .conductor-flex .conductor-widget-2-columns .custom-field,
 	.baton-note-sidebar .conductor-flex .conductor-widget-2-columns .custom-field,
 	.conductor-widget-5-columns .content .article-title-wrap,
 	.conductor-widget-5-columns .content .article-content,
 	.conductor-widget-5-columns .article-post-meta,
+	.conductor-widget-5-columns .article-post-meta.has-meta,
 	.conductor-widget-5-columns.conductor-flex .custom-field,
 	.conductor.conductor-baton-landing-page-active .conductor-flex .conductor-widget-5-columns .custom-field,
 	.baton-note-sidebar .conductor-flex .conductor-widget-5-columns .custom-field,
 	.conductor-widget-6-columns .content .article-title-wrap,
 	.conductor-widget-6-columns .content .article-content,
 	.conductor-widget-6-columns .article-post-meta,
+	.conductor-widget-6-columns .article-post-meta.has-meta,
 	.conductor-widget-6-columns.conductor-flex .custom-field,
 	.conductor.conductor-baton-landing-page-active .conductor-flex .conductor-widget-6-columns .custom-field,
 	.baton-note-sidebar .conductor-flex .conductor-widget-6-columns .custom-field {

--- a/theme/class-baton.php
+++ b/theme/class-baton.php
@@ -4,7 +4,7 @@
  *
  * @class Baton
  * @author Slocum Studio
- * @version 1.1.0
+ * @version 1.1.1
  * @since 1.0.0
  */
 
@@ -17,7 +17,7 @@ if ( ! class_exists( 'Baton' ) ) {
 		/**
 		 * @var string, Current version number
 		 */
-		public $version = '1.1.0';
+		public $version = '1.1.1';
 
 		/**
 		 * @var string, Slug for Slocum Theme support


### PR DESCRIPTION
- Adjusted CSS for Conductor Widgets in various configurations/areas
- Fixed a display bug where WooCommerce up-sells on single products were
too small
- Fixed a display bug where mc-gravity confirmation had a white
background