### PR TITLE
Version 1.1.2

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,9 +2,16 @@
 Theme: Baton Pro
 Author: Slocum Themes/Slocum Design Studio
 Author URI: https://slocumthemes.com/
-Current Version: 1.1.1
+Current Version: 1.1.2
 ==========================================
 
+
+1.1.2 // March 31 2017
+----------------------
+- Adjusted "before" and "after" actions in the Baton::conductor_widget_featured_image() callback to ensure
+  they were triggered regardless of the current post featured image existence
+- Introduced "Show or Hide Categories/Tags Above Post Titles" Theme Option
+- Adjusted padding on elements inside of Conductor Widget table displays within content
 
 1.1.1 // March 10 2017
 ----------------------

--- a/functions.php
+++ b/functions.php
@@ -193,6 +193,12 @@ if ( ! function_exists( 'sds_post_meta' ) ) {
  */
 if ( ! function_exists( 'baton_categories_tags' ) ) {
 	function baton_categories_tags( $force_display = false ) {
+		global $sds_theme_options;
+
+		// Bail we shouldn't show categories and tags above post titles
+		if ( $sds_theme_options['baton']['hide_cats_tags_above_post_titles'] )
+			return;
+
 		// Grab categories and tags
 		$categories = get_the_category();
 		$tags = get_the_tags();

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@
  * Text Domain: baton-pro
  * Author: Slocum Studio
  * Author URI: https://slocumthemes.com/
- * Version: 1.1.1
+ * Version: 1.1.2
  * License: GPL2+
  * License URI: http://www.gnu.org/licenses/gpl.html
  * Tags: one-column, two-columns, left-sidebar, right-sidebar, grid-layout, custom-background, custom-colors, custom-menu, editor-style, featured-images, footer-widgets, full-width-template, sticky-post, theme-options, threaded-comments, translation-ready, blog, e-commerce, education, entertainment, food-and-drink, news, photography, portfolio
@@ -1955,6 +1955,17 @@ a img.aligncenter {
 	margin-top: 0;
 }
 
+.content .conductor-table .article-content,
+.page .content .conductor-table .article-content,
+.content.no-posts .conductor-table .article-content,
+.attachment .content .conductor-table .article-content,
+.content .conductor-table .article-title-wrap,
+.page .content .conductor-table .article-title-wrap,
+.content.no-posts .conductor-table .article-title-wrap,
+.attachment .content .conductor-table .article-title-wrap {
+	padding: 0;
+}
+
 .conductor-widget-grid .content .article-title-wrap,
 .conductor-widget-grid .content .article-content {
 	padding: 0 1rem;
@@ -2625,11 +2636,14 @@ nav .primary-nav .children .children:after {
 	padding: 0;
 }
 
-.content .article-title-wrap, .content .article-content {
+.content .article-title-wrap,
+.content .article-content {
 	padding: 0 6rem;
 }
 
-.page .content .article-content, .content.no-posts .article-content, .attachment .content .article-content {
+.page .content .article-content,
+.content.no-posts .article-content,
+.attachment .content .article-content {
 	padding-bottom: 2rem;
 }
 


### PR DESCRIPTION
- Adjusted "before" and "after" actions in the
Baton::conductor_widget_featured_image() callback to ensure they were
triggered regardless of the current post featured image existence
- Introduced "Show or Hide Categories/Tags Above Post Titles" Theme
Option
- Adjusted padding on elements inside of Conductor Widget table displays
within content